### PR TITLE
Support more architectures

### DIFF
--- a/BENCHMARK_GB200.md
+++ b/BENCHMARK_GB200.md
@@ -1,0 +1,26 @@
+# KDA forward benchmark (Blackwell / GB200)
+
+- Generated: 2026-05-26
+
+- Command: `python benchmarks/generate_benchmark_md.py -o BENCHMARK_GB200.md --device-label Blackwell / GB200`
+
+- Benchmark settings: `warmup=30`, `iters=200`, `repeats=5`
+
+- `fla_chunk_kda` configuration: `use_gate_in_kernel=True`, `use_qk_l2norm_in_kernel=True`, `use_beta_sigmoid_in_kernel=True`, `lower_bound=-5`, `transpose_state_layout=True`
+- `fla_chunk_gated_delta_rule` configuration: scalar per-head gate `g` of shape `(1, T, H)`, `use_qk_l2norm_in_kernel=True`, `transpose_state_layout=True`
+
+### `T=8192`, `H=96`, `D=128`
+
+| Case | `flash_kda` mean (ms) | `fla_chunk_kda` mean (ms) | Speedup vs `chunk_kda` | `fla_chunk_gdn` mean (ms) | Speedup vs `gdn` |
+|------|----------------------:|----------------------:|--------:|----------------------:|--------:|
+| Fixed | 1.0087 | 2.3271 | 2.31× | 1.2792 | 1.27× |
+| Varlen, `seq_lens`=[1300, 547, 2048, 963, 271, 3063] | 0.8597 | 2.3340 | 2.71× | 1.2962 | 1.51× |
+| Varlen, `seq_lens`=`1024 x 8` | 0.7064 | 2.3105 | 3.27× | 1.2744 | 1.80× |
+
+### `T=8192`, `H=64`, `D=128`
+
+| Case | `flash_kda` mean (ms) | `fla_chunk_kda` mean (ms) | Speedup vs `chunk_kda` | `fla_chunk_gdn` mean (ms) | Speedup vs `gdn` |
+|------|----------------------:|----------------------:|--------:|----------------------:|--------:|
+| Fixed | 0.9247 | 1.5764 | 1.70× | 0.8857 | 0.96× |
+| Varlen, `seq_lens`=[1300, 547, 2048, 963, 271, 3063] | 0.6553 | 1.5843 | 2.42× | 0.9053 | 1.38× |
+| Varlen, `seq_lens`=`1024 x 8` | 0.4811 | 1.5422 | 3.21× | 0.8683 | 1.80× |

--- a/README.md
+++ b/README.md
@@ -16,8 +16,16 @@ FlashKDA: Flash Kimi Delta Attention — high-performance KDA kernels built on C
 git clone https://github.com/MoonshotAI/FlashKDA.git flash-kda
 cd flash-kda
 git submodule update --init --recursive
-pip install -v .
+pip install -v --no-build-isolation .
 ```
+
+By default, the build detects the current CUDA device and compiles for that architecture. For wheel or CI builds, compile all supported architectures explicitly:
+
+```bash
+FLASH_KDA_CUDA_ARCHS=all pip install -v --no-build-isolation .
+```
+
+Supported values are `auto` (default), `all`, or a comma-separated arch list such as `90a,100a`.
 
 ## Using FlashKDA as an FLA backend
 

--- a/benchmarks/generate_benchmark_md.py
+++ b/benchmarks/generate_benchmark_md.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Run ``bench_fwd.py`` twice (default ``H`` and ``--H 64``), parse stdout, and write
-``BENCHMARK_H20.md`` at repo root.
+a benchmark markdown report.
 
 Reports mean latency for ``flash_kda (fp32 state)`` and ``fla_chunk_kda`` (FLA
 ``chunk_kda``), plus speedup ``chunk_mean / flash_mean``. Generated date is UTC,
@@ -20,6 +20,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BENCH_FWD = Path(__file__).resolve().parent / "bench_fwd.py"
 DEFAULT_OUT = REPO_ROOT / "BENCHMARK_H20.md"
+DEFAULT_DEVICE_LABEL = "Hopper / H20"
 
 # Matches ``chunk_kda(...)`` in ``benchmarks/bench_fwd.py`` (documented in the report).
 FLA_CHUNK_KDA_OPTIONS_MD = (
@@ -238,13 +239,19 @@ def render_markdown(
     sections: list[list[dict]],
     generated_at: str,
     generator_cmd: str,
+    device_label: str,
 ) -> str:
     """
     *sections*: one ``cases`` list per table (default ``H``, then ``H=64``).
-    *generator_cmd*: command that reproduces this report (``generate_benchmark_hopper_h20_md.py``).
+    *generator_cmd*: command that reproduces this report.
+    *device_label*: device/platform label printed in the report title.
     """
+    title = "# KDA forward benchmark"
+    if device_label:
+        title += f" ({device_label})"
+
     lines: list[str] = [
-        "# KDA forward benchmark (Hopper / H20)",
+        title,
         "",
         f"- Generated: {generated_at}",
         "",
@@ -282,7 +289,7 @@ def render_markdown(
 
 def main() -> None:
     p = argparse.ArgumentParser(
-        description="Run bench_fwd.py and write BENCHMARK_H20.md at repository root."
+        description="Run bench_fwd.py and write a benchmark markdown report."
     )
     p.add_argument(
         "-o",
@@ -291,12 +298,21 @@ def main() -> None:
         default=DEFAULT_OUT,
         help=f"Output markdown path (default: {DEFAULT_OUT})",
     )
+    p.add_argument(
+        "--device-label",
+        default=DEFAULT_DEVICE_LABEL,
+        help=f"Device/platform label for the report title (default: {DEFAULT_DEVICE_LABEL!r})",
+    )
     args, bench_extra = p.parse_known_args()
 
     def _fmt_generator_cmd(extra: list[str]) -> str:
+        cmd = "python benchmarks/generate_benchmark_md.py"
+        if args.output != DEFAULT_OUT:
+            cmd += f" -o {args.output}"
+        if args.device_label != DEFAULT_DEVICE_LABEL:
+            cmd += f" --device-label {args.device_label}"
         tail = " ".join(extra)
-        base = "python benchmarks/generate_benchmark_hopper_h20_md.py"
-        return f"{base} {tail}".strip() if tail else base
+        return f"{cmd} {tail}".strip() if tail else cmd
 
     argv_default = list(bench_extra)
     argv_h64 = _argv_with_h(bench_extra, 64)
@@ -316,7 +332,7 @@ def main() -> None:
         )
 
     generated = _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d")
-    md = render_markdown(sections, generated, _fmt_generator_cmd(bench_extra))
+    md = render_markdown(sections, generated, _fmt_generator_cmd(bench_extra), args.device_label)
     out_path = args.output.resolve()
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(md, encoding="utf-8")

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,40 @@ def get_nvcc_thread_args():
     return ["--threads", nvcc_threads]
 
 
+SUPPORTED_CUDA_ARCHS = ["90a", "100a", "103a", "120a"]
+
+
+def detect_cuda_arch():
+    import torch
+
+    if not torch.cuda.is_available():
+        return None
+
+    major, minor = torch.cuda.get_device_capability(torch.cuda.current_device())
+    return f"{major}{minor}a"
+
+
 def get_arch_flags():
-    # TODO: add compile flags here to support more architectures
     assert CUDA_HOME is not None, "PyTorch must be compiled with CUDA support"
-    DISABLE_SM90 = is_flag_set("FLASH_KDA_DISABLE_SM90")
-    arch_flags = []
-    if not DISABLE_SM90:
-        arch_flags.extend(["-gencode", "arch=compute_90a,code=sm_90a"])
-    return arch_flags
+
+    requested = os.getenv("FLASH_KDA_CUDA_ARCHS", "auto").lower()
+    if requested == "auto":
+        arch = detect_cuda_arch()
+        if arch is None:
+            raise RuntimeError(
+                "FLASH_KDA_CUDA_ARCHS=auto requires a visible CUDA device. "
+                "Set FLASH_KDA_CUDA_ARCHS=all to build all supported archs."
+            )
+        archs = [arch]
+    elif requested == "all":
+        archs = SUPPORTED_CUDA_ARCHS
+    else:
+        archs = [arch.strip() for arch in requested.split(",") if arch.strip()]
+
+    flags = []
+    for arch in archs:
+        flags.extend(["-gencode", f"arch=compute_{arch},code=sm_{arch}"])
+    return flags
 
 
 ext_modules = [


### PR DESCRIPTION
This PR adds configurable CUDA architecture selection during extension builds.
- Defaults to `FLASH_KDA_CUDA_ARCHS=auto`, which detects the current CUDA device and builds only that arch -> useful for installing the latest version
- Supports `FLASH_KDA_CUDA_ARCHS=all` for wheel/CI builds. This currently builds all architectures that have TMA: sm90a, sm100a, sm103a, and sm120a
- Allows explicit comma-separated arch lists, e.g. `FLASH_KDA_CUDA_ARCHS=90a,100a`

Tested with GB200. `python tests/test_fwd.py` is successful