### PR TITLE
Support old gate equation

### DIFF
--- a/csrc/flash_kda.cpp
+++ b/csrc/flash_kda.cpp
@@ -33,7 +33,7 @@ void fwd(
     torch::Tensor workspace,
     torch::Tensor A_log,
     torch::Tensor dt_bias,
-    double lower_bound,
+    std::optional<double> lower_bound,
     std::optional<torch::Tensor> initial_state = std::nullopt,
     std::optional<torch::Tensor> final_state = std::nullopt,
     std::optional<torch::Tensor> cu_seqlens = std::nullopt
@@ -122,7 +122,8 @@ void fwd(
     auto out_ptr = reinterpret_cast<cutlass::bfloat16_t*>(out_3d.data_ptr<at::BFloat16>());
     auto A_log_ptr = A_log.data_ptr<float>();
     auto dt_bias_ptr = dt_bias.data_ptr<float>();
-    float gate_scale = float(lower_bound * 1.4426950408889634);
+    bool use_lower_bound = lower_bound.has_value();
+    float gate_scale = float(lower_bound.value_or(0.0) * 1.4426950408889634);
 
     // Transpose beta: [T_total, H] -> [H, T_total] (1D TMA, no T alignment constraint)
     auto beta_t = beta_2d.t().contiguous();
@@ -178,35 +179,39 @@ void fwd(
     }
 
     // Dispatch based on state configuration and varlen
-    #define LAUNCH(HI, HO, FP32, VL) \
-        launch_fwd<128, HI, HO, FP32, VL>( \
+    #define LAUNCH(HI, HO, FP32, LB, VL) \
+        launch_fwd<128, HI, HO, FP32, LB, VL>( \
             q_ptr, k_ptr, v_ptr, g_ptr, beta_t_ptr, \
             initial_state_raw, scale_f, final_state_raw, out_ptr, \
             workspace_ptr, total_tiles, \
             int(T_total), int(H), int(N_val), cu_seqlens_dev, \
             A_log_ptr, dt_bias_ptr, gate_scale, stream)
 
-    #define DISPATCH_STATE(VL) \
+    #define DISPATCH_STATE(LB, VL) \
         if (!has_state_in && !has_state_out) { \
-            LAUNCH(false, false, false, VL); \
+            LAUNCH(false, false, false, LB, VL); \
         } else if (has_state_in && has_state_out && state_fp32) { \
-            LAUNCH(true, true, true, VL); \
+            LAUNCH(true, true, true, LB, VL); \
         } else if (has_state_in && has_state_out && !state_fp32) { \
-            LAUNCH(true, true, false, VL); \
+            LAUNCH(true, true, false, LB, VL); \
         } else if (!has_state_in && has_state_out && state_fp32) { \
-            LAUNCH(false, true, true, VL); \
+            LAUNCH(false, true, true, LB, VL); \
         } else if (!has_state_in && has_state_out && !state_fp32) { \
-            LAUNCH(false, true, false, VL); \
+            LAUNCH(false, true, false, LB, VL); \
         } else if (has_state_in && !has_state_out && state_fp32) { \
-            LAUNCH(true, false, true, VL); \
+            LAUNCH(true, false, true, LB, VL); \
         } else { \
-            LAUNCH(true, false, false, VL); \
+            LAUNCH(true, false, false, LB, VL); \
         }
 
-    if (is_varlen) {
-        DISPATCH_STATE(true);
+    if (is_varlen && use_lower_bound) {
+        DISPATCH_STATE(true, true);
+    } else if (is_varlen) {
+        DISPATCH_STATE(false, true);
+    } else if (use_lower_bound) {
+        DISPATCH_STATE(true, false);
     } else {
-        DISPATCH_STATE(false);
+        DISPATCH_STATE(false, false);
     }
 
     #undef DISPATCH_STATE

--- a/csrc/fwd.h
+++ b/csrc/fwd.h
@@ -3,7 +3,7 @@
 
 #include <cutlass/bfloat16.h>
 
-template <int D, bool HasStateIn = true, bool HasStateOut = true, bool StateFP32 = false, bool IsVarlen = true>
+template <int D, bool HasStateIn = true, bool HasStateOut = true, bool StateFP32 = false, bool USE_LOWER_BOUND = false, bool IsVarlen = true>
 void launch_fwd(
     cutlass::bfloat16_t const* q_ptr,
     cutlass::bfloat16_t const* k_ptr,

--- a/csrc/smxx/fwd_kernel1.cuh
+++ b/csrc/smxx/fwd_kernel1.cuh
@@ -94,6 +94,7 @@ template <
     int CHUNK,
     int D,
     int NumThreads,
+    bool USE_LOWER_BOUND = false,
     bool IsVarlen = true
 >
 __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
@@ -300,8 +301,13 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
                 float g_val;
                 if (row < actual_len) {
                     g_val = bf16_to_f32(g_bf16_smem[row * D + col]) + dt;
-                    g_val = a_log_exp * g_val;
-                    g_val = gate_scale * sigmoid_tanh_approx_f32(g_val);
+                    if constexpr (USE_LOWER_BOUND) {
+                        g_val = a_log_exp * g_val;
+                        g_val = gate_scale * sigmoid_tanh_approx_f32(g_val);
+                    } else {
+                        g_val = g_val > 20.0f ? g_val : __logf(1.0f + __expf(g_val));
+                        g_val *= -a_log_exp * 1.4426950408889634f;
+                    }
                 } else {
                     g_val = 0.0f;
                 }

--- a/csrc/smxx/fwd_launch.cu
+++ b/csrc/smxx/fwd_launch.cu
@@ -3,7 +3,7 @@
 #include "fwd_kernel2.cuh"
 
 // ==================== launch_fwd ====================
-template <int D, bool HasStateIn, bool HasStateOut, bool StateFP32, bool IsVarlen>
+template <int D, bool HasStateIn, bool HasStateOut, bool StateFP32, bool USE_LOWER_BOUND, bool IsVarlen>
 void launch_fwd(
     cutlass::bfloat16_t const* q_ptr,
     cutlass::bfloat16_t const* k_ptr,
@@ -154,7 +154,7 @@ void launch_fwd(
             decltype(tma_load_g), decltype(tma_load_dt_bias),
             decltype(tma_store_ws_kd), decltype(tma_store_ws_qd), decltype(tma_store_ws_kr),
             decltype(tma_store_ws_gt), decltype(tma_store_ws_inv), decltype(tma_store_ws_mqk),
-            CHUNK, D, kK1Threads, IsVarlen
+            CHUNK, D, kK1Threads, USE_LOWER_BOUND, IsVarlen
         >;
 
         cudaFuncSetAttribute(kernel1, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_k1);
@@ -210,22 +210,24 @@ void launch_fwd(
 }
 
 // Explicit instantiations
-#define INSTANTIATE_LAUNCH_FWD(D, HI, HO, FP32, VL) \
-    template void launch_fwd<D, HI, HO, FP32, VL>( \
+#define INSTANTIATE_LAUNCH_FWD(D, HI, HO, FP32, LB, VL) \
+    template void launch_fwd<D, HI, HO, FP32, LB, VL>( \
         cutlass::bfloat16_t const*, cutlass::bfloat16_t const*, \
         cutlass::bfloat16_t const*, cutlass::bfloat16_t const*, \
         cutlass::bfloat16_t const*, void const*, float, void*, \
         cutlass::bfloat16_t*, void*, int, int, int, int, \
         int64_t const*, float const*, float const*, float, cudaStream_t);
 
-#define INSTANTIATE_STATE_VARIANTS(VL) \
-    INSTANTIATE_LAUNCH_FWD(128, true,  true,  false, VL) \
-    INSTANTIATE_LAUNCH_FWD(128, true,  true,  true,  VL) \
-    INSTANTIATE_LAUNCH_FWD(128, false, false, false, VL) \
-    INSTANTIATE_LAUNCH_FWD(128, false, true,  false, VL) \
-    INSTANTIATE_LAUNCH_FWD(128, true,  false, false, VL) \
-    INSTANTIATE_LAUNCH_FWD(128, false, true,  true,  VL) \
-    INSTANTIATE_LAUNCH_FWD(128, true,  false, true,  VL)
+#define INSTANTIATE_STATE_VARIANTS_LOWER_BOUND(VL, LB) \
+    INSTANTIATE_LAUNCH_FWD(128, true,  true,  false, LB, VL) \
+    INSTANTIATE_LAUNCH_FWD(128, true,  true,  true,  LB, VL) \
+    INSTANTIATE_LAUNCH_FWD(128, false, false, false, LB, VL) \
+    INSTANTIATE_LAUNCH_FWD(128, false, true,  false, LB, VL) \
+    INSTANTIATE_LAUNCH_FWD(128, true,  false, false, LB, VL) \
+    INSTANTIATE_LAUNCH_FWD(128, false, true,  true,  LB, VL) \
+    INSTANTIATE_LAUNCH_FWD(128, true,  false, true,  LB, VL)
 
-INSTANTIATE_STATE_VARIANTS(true)   // varlen
-INSTANTIATE_STATE_VARIANTS(false)  // non-varlen
+INSTANTIATE_STATE_VARIANTS_LOWER_BOUND(true, false)   // varlen, no lower_bound
+INSTANTIATE_STATE_VARIANTS_LOWER_BOUND(true, true)    // varlen, lower_bound
+INSTANTIATE_STATE_VARIANTS_LOWER_BOUND(false, false)  // non-varlen, no lower_bound
+INSTANTIATE_STATE_VARIANTS_LOWER_BOUND(false, true)   // non-varlen, lower_bound


### PR DESCRIPTION
I'm working on FlashKDA integration in vLLM. Right now the only released OSS model with KDA is https://huggingface.co/moonshotai/Kimi-Linear-48B-A3B-Instruct, which uses the old gate equation

Old gate equation (no `lower_bound`)

```
g = -exp(A_log) * softplus(a + dt_bias)
```

New gate equation (with `lower_bound`, currently used in FlashKDA)

```
g = lower_bound * sigmoid(exp(A_log) * (a + dt_bias))
```

This PR adds support for the old-style gate to simplify vLLM integration (no need to check for old vs new gate) + correctness validation with the current Kimi-Linear.