### PR TITLE
Report CUTLASS setup and CUDA launch-configuration failures

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include build_utils.py

--- a/build_utils.py
+++ b/build_utils.py
@@ -1,0 +1,23 @@
+import subprocess
+
+
+def update_cutlass_submodule(repo_dir: str) -> None:
+    command = ["git", "submodule", "update", "--init", "cutlass"]
+    try:
+        subprocess.run(command, cwd=repo_dir, check=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "Failed to initialize the CUTLASS submodule because Git was not found. "
+            "Install Git and run `git submodule update --init --recursive`."
+        ) from exc
+    except (OSError, subprocess.CalledProcessError) as exc:
+        detail = (
+            f" (Git exited with status {exc.returncode})"
+            if isinstance(exc, subprocess.CalledProcessError)
+            else ""
+        )
+        raise RuntimeError(
+            "Failed to initialize the CUTLASS submodule"
+            f"{detail}. Run `git submodule update --init --recursive` "
+            "from the FlashKDA repository and retry the installation."
+        ) from exc

--- a/csrc/smxx/fwd_launch.cu
+++ b/csrc/smxx/fwd_launch.cu
@@ -2,6 +2,8 @@
 #include "fwd_kernel1.cuh"
 #include "fwd_kernel2.cuh"
 
+#include <c10/cuda/CUDAException.h>
+
 // ==================== launch_fwd ====================
 template <int D, bool HasStateIn, bool HasStateOut, bool StateFP32, bool IsVarlen>
 void launch_fwd(
@@ -157,7 +159,8 @@ void launch_fwd(
             CHUNK, D, kK1Threads, IsVarlen
         >;
 
-        cudaFuncSetAttribute(kernel1, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_k1);
+        C10_CUDA_CHECK(cudaFuncSetAttribute(
+            kernel1, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_k1));
 
         dim3 grid_k1(total_tiles, H);
         dim3 block_k1(kK1Threads);
@@ -191,7 +194,8 @@ void launch_fwd(
             HasStateIn, HasStateOut, StateFP32, IsVarlen
         >;
 
-        cudaFuncSetAttribute(kernel2, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_k2);
+        C10_CUDA_CHECK(cudaFuncSetAttribute(
+            kernel2, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_k2));
 
         dim3 grid_k2(N, H);
         dim3 block_k2(kK2Threads);

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,10 @@ import subprocess
 from setuptools import setup
 from torch.utils.cpp_extension import CUDAExtension, BuildExtension, CUDA_HOME
 
+from build_utils import update_cutlass_submodule
+
 this_dir = os.path.dirname(os.path.abspath(__file__))
-subprocess.run(["git", "submodule", "update", "--init", "cutlass"])
+update_cutlass_submodule(this_dir)
 
 
 def is_flag_set(flag: str) -> bool:

--- a/tests/test_build_utils.py
+++ b/tests/test_build_utils.py
@@ -1,0 +1,41 @@
+import subprocess
+from unittest import mock
+
+import pytest
+
+from build_utils import update_cutlass_submodule
+
+
+def test_update_cutlass_submodule_runs_from_repository(tmp_path):
+    with mock.patch("build_utils.subprocess.run") as run:
+        update_cutlass_submodule(str(tmp_path))
+
+    run.assert_called_once_with(
+        ["git", "submodule", "update", "--init", "cutlass"],
+        cwd=str(tmp_path),
+        check=True,
+    )
+
+
+def test_update_cutlass_submodule_reports_git_failure(tmp_path):
+    error = subprocess.CalledProcessError(128, ["git", "submodule"])
+
+    with mock.patch("build_utils.subprocess.run", side_effect=error):
+        with pytest.raises(
+            RuntimeError,
+            match=r"Failed to initialize the CUTLASS submodule "
+            r"\(Git exited with status 128\).*git submodule update",
+        ):
+            update_cutlass_submodule(str(tmp_path))
+
+
+def test_update_cutlass_submodule_reports_missing_git(tmp_path):
+    with mock.patch(
+        "build_utils.subprocess.run",
+        side_effect=FileNotFoundError("git"),
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match=r"CUTLASS submodule because Git was not found",
+        ):
+            update_cutlass_submodule(str(tmp_path))


### PR DESCRIPTION
## TL;DR

Fail at the operation that caused a setup or CUDA configuration error instead of continuing to a later, less actionable failure.

Closes #15.

## Motivation

Two initialization boundaries currently discard errors:

| Boundary | Current behavior | New behavior |
|---|---|---|
| CUTLASS submodule initialization | Ignore the Git exit status and continue toward compilation | Run from the repository root, check the exit status, and report an actionable error |
| CUDA dynamic shared-memory configuration | Ignore `cudaFuncSetAttribute` results | Propagate the CUDA error through `C10_CUDA_CHECK` |

The documented clone and submodule workflow remains valid. This change improves reporting when that workflow or launch configuration fails.

## Changes

- Move CUTLASS initialization into a small testable setup helper.
- Run `git submodule update --init cutlass` from the repository root.
- Enable `check=True` for the Git subprocess.
- Distinguish a missing Git executable from a nonzero Git exit.
- Include the helper in source distributions.
- Check both kernel `cudaFuncSetAttribute` calls with `C10_CUDA_CHECK`.

No architecture selection, kernel launch dimensions, shared-memory sizes, or successful setup behavior changes.

## Suggested review order

1. `build_utils.py` — setup failure boundary and diagnostics.
2. `tests/test_build_utils.py` — subprocess behavior.
3. `setup.py` and `MANIFEST.in` — setup integration and source-distribution inclusion.
4. `csrc/smxx/fwd_launch.cu` — CUDA error propagation.

The two commits are intentionally separated: the first implements the diagnostics, and the second ensures the new setup helper is present in source distributions.

## Validation

- `python -m pytest -q tests/test_build_utils.py` — 3 passed.
- Built a source distribution and verified that it contains `build_utils.py`.
- Confirmed that the supported PyTorch CUDA headers define `C10_CUDA_CHECK`.
- `python -m py_compile build_utils.py setup.py tests/test_build_utils.py`
- `git diff --check origin/master...HEAD`
