### PR TITLE
Fix missing proxy fences around TMA accesses

### DIFF
--- a/csrc/smxx/fwd_kernel1.cuh
+++ b/csrc/smxx/fwd_kernel1.cuh
@@ -184,6 +184,7 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     if (threadIdx.x == 0) {
         using BarrierType = cutlass::arch::ClusterTransactionBarrier::ValueType;
         shared_storage.tma_load_barrier.init(1);
+        cutlass::arch::fence_barrier_init();  // generic init -> visible to async proxy (TMA complete-tx)
         shared_storage.tma_load_barrier.arrive_and_expect_tx(kTmaTransactionBytes);
 
         Tensor g_q = tma_load_q.get_tma_tensor(make_shape(H, T_total, D));

--- a/csrc/smxx/fwd_kernel2.cuh
+++ b/csrc/smxx/fwd_kernel2.cuh
@@ -245,6 +245,7 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             constexpr uint32_t kStateTransactionBytes = cute::cosize_v<StateSmemLayout> * sizeof(BF16);
 
             shared_storage.state_acc_tma_barrier.init(1);
+            cutlass::arch::fence_barrier_init();  // generic init -> visible to async proxy (TMA complete-tx)
             shared_storage.state_acc_tma_barrier.arrive_and_expect_tx(kStateTransactionBytes);
 
             Tensor g_init = tma_load_initial_state.get_tma_tensor(make_shape(N * H, D, D));
@@ -273,6 +274,7 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             constexpr uint32_t kFP32StateTransactionBytes = cute::cosize_v<StateSmemLayout> * sizeof(float);
 
             shared_storage.state_acc_tma_barrier.init(1);
+            cutlass::arch::fence_barrier_init();  // generic init -> visible to async proxy (TMA complete-tx)
             shared_storage.state_acc_tma_barrier.arrive_and_expect_tx(kFP32StateTransactionBytes);
 
             Tensor g_init = tma_load_initial_state.get_tma_tensor(make_shape(N * H, D, D));
@@ -309,6 +311,8 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
                 buf[i] = BF16(0);
             }
         }
+        // generic writes -> visible to async proxy (TMA state store covers t_tiles==0)
+        cutlass::arch::fence_view_async_shared();
         __syncthreads();
     }
 #endif
@@ -808,6 +812,7 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             shared_storage.state_acc.begin(),
             reinterpret_cast<float*>(shared_storage.state_fp32_buf),
             threadIdx.x);
+        cutlass::arch::fence_view_async_shared();  // generic-proxy writes -> visible to async proxy (TMA)
         __syncthreads();  // conversion complete
 
         if (warp_role == WarpRole::STORE && lane_predicate) {


### PR DESCRIPTION
## Summary

Fixes the missing cross-proxy fences reported in #24 (found by auditing the SM90 forward kernels against the PTX ISA proxy model):

- **`fwd_kernel2.cuh` — FP32 state store**: `smem_cvt_bf16_to_fp32()` writes `state_fp32_buf` via the generic proxy, but only `__syncthreads()` separated it from the TMA store (async proxy). Added `fence_view_async_shared()` executed by all writing threads before the rendezvous — same pattern as the existing per-iteration fence before `producer_commit`.
- **`fwd_kernel2.cuh` — zero-init state (`HasStateIn=false`)**: with an empty sequence (`t_tiles == 0`, reachable in varlen batches) the main loop never runs, so no fence ever covered the generic zero-init writes before the BF16 TMA state store → stale smem could be written to `final_state`. Added `fence_view_async_shared()` before the `__syncthreads()`.
- **`fwd_kernel1.cuh` / `fwd_kernel2.cuh` — 3 standalone mbarriers**: `mbarrier.init` (generic write) was used by TMA complete-tx (async proxy RMW) without `fence.mbarrier_init`. Added `fence_barrier_init()` after each init, matching `CUTLASS PipelineTmaAsync::init_barriers`.

All changes are writer-side fences placed immediately after the last write and before the existing rendezvous (`__syncthreads` / barrier arrive), per the PTX generic→async publication pattern. 6 lines added, no other changes.

## Test

- `python setup.py build_ext --inplace` — clean build (CUDA 13.0, torch 2.9.1)
- `python tests/test_fwd.py` — fixed-length and varlen cases both **bit-exact** vs torch reference (avg/max rtol/atol = 0.0)

Closes #24
